### PR TITLE
update bls_mps_ro_variant to bls_mps_ro_version

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,8 +23,8 @@ using namespace nil::crypto3::multiprecision;
 
     using curve_type = curves::bls12_381;
     using hash_type = sha2<256>;
-    using bls_variant = bls_mps_ro_variant<curve_type, hash_type>;
-    using scheme_type = bls<bls_variant, bls_basic_scheme>;
+    using bls_version = bls_mps_ro_version<curve_type, hash_type>;
+    using scheme_type = bls<bls_default_public_params<>, bls_version, bls_basic_scheme, curve_type>;
 
     using privkey_type = private_key<scheme_type>;
     using pubkey_type = public_key<scheme_type>;
@@ -67,8 +67,8 @@ using namespace nil::crypto3::multiprecision;
 
     using curve_type = curves::bls12_381;
     using hash_type = sha2<256>;
-    using bls_variant = bls_mps_ro_variant<curve_type, hash_type>;
-    using scheme_type = bls<bls_variant, bls_basic_scheme>;
+    using bls_version = bls_mps_ro_version<curve_type, hash_type>;
+    using scheme_type = bls<bls_default_public_params<>, bls_version, bls_basic_scheme, curve_type>;
 
     using privkey_type = private_key<scheme_type>;
     using pubkey_type = public_key<scheme_type>;


### PR DESCRIPTION
I do not know if this compiles. this has not been tested. but it is clear that _variant changed to _version and this now matches https://github.com/NilFoundation/crypto3-pubkey/blob/6b0675a86f5255197d319d877a1908185625ddb0/test/bls.cpp

see also https://github.com/NilFoundation/crypto3-pkmodes/pull/5