### PR TITLE
style improvement when using BOOST macros

### DIFF
--- a/include/nil/crypto3/pubkey/type_traits.hpp
+++ b/include/nil/crypto3/pubkey/type_traits.hpp
@@ -38,7 +38,6 @@ namespace nil {
             using namespace boost::mpl::placeholders;
 
             BOOST_TTI_HAS_STATIC_MEMBER_DATA(context)
-
             template<typename T>
             struct is_eddsa_params {
                 static constexpr bool value = has_static_member_data_context<T, const typename T::context_type>::value;

--- a/include/nil/crypto3/pubkey/type_traits.hpp
+++ b/include/nil/crypto3/pubkey/type_traits.hpp
@@ -37,10 +37,10 @@ namespace nil {
 
             using namespace boost::mpl::placeholders;
 
-            BOOST_TTI_HAS_STATIC_MEMBER_DATA(context)
+            BOOST_TTI_TRAIT_HAS_STATIC_MEMBER_DATA(has_eddsa_context, context)
             template<typename T>
             struct is_eddsa_params {
-                static constexpr bool value = has_static_member_data_context<T, const typename T::context_type>::value;
+                static constexpr bool value = has_eddsa_context<T, const typename T::context_type>::value;
                 typedef T type;
             };
 


### PR DESCRIPTION
https://github.com/NilFoundation/crypto3-pubkey/issues/27#issuecomment-1046118845

I also suggest style improvement from using the `_TRAIT_` variation of BOOST_TTI macros, as in:

```
        BOOST_TTI_TRAIT_HAS_STATIC_MEMBER_DATA(has_eddsa_context, context)
        template<typename T>
        struct is_eddsa_params {
            static constexpr bool value = has_eddsa_context<T, const typename T::context_type>::value;
            typedef T type;
        };
```